### PR TITLE
Added json cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 venv/
 .env
+cache*


### PR DESCRIPTION
The script now loads a cache stored at `cache.json`. The main loop checks if the EMP address is in the cache and if so skips info retrieval for that address.